### PR TITLE
Fix missing PDF blob function

### DIFF
--- a/src/services/pdfService.ts
+++ b/src/services/pdfService.ts
@@ -152,6 +152,24 @@ export const generatePDF = (invoice: Invoice): jsPDF => {
 };
 
 /**
+ * Convierte un documento PDF en un Blob sin descargarlo.
+ * @param pdfDoc Documento PDF generado
+ * @returns Blob del PDF
+ */
+export const generatePdfBlob = (pdfDoc: jsPDF): Blob => {
+  try {
+    return pdfDoc.output('blob');
+  } catch (error) {
+    console.error('Error al convertir PDF a Blob:', error);
+    throw new Error(
+      `Error al convertir PDF a Blob: ${
+        error instanceof Error ? error.message : 'Error desconocido'
+      }`
+    );
+  }
+};
+
+/**
  * Descarga el PDF como archivo
  * @param pdfDoc Documento PDF generado
  * @param consecutivo Número consecutivo de la factura


### PR DESCRIPTION
## Summary
- add `generatePdfBlob` helper to create a Blob from a generated PDF
- use the new helper in `processAndSendInvoice`

## Testing
- `npm run lint` *(fails: 247 errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6844879e173c832196475ffc6804ca16