### PR TITLE
Remove VITE_ prefixes in Hacienda auth service

### DIFF
--- a/src/services/haciendaAuthService.ts
+++ b/src/services/haciendaAuthService.ts
@@ -19,10 +19,10 @@ interface TokenResponse {
 export const getAccessToken = async (): Promise<TokenResponse> => {
   try {
     // Obtener credenciales desde las variables de entorno
-    const username = envService.get('VITE_HACIENDA_USERNAME');
-    const password = envService.get('VITE_HACIENDA_PASSWORD');
-    const clientId = envService.get('VITE_HACIENDA_CLIENT_ID');
-    const tokenUrl = envService.get('VITE_HACIENDA_TOKEN_URL');
+    const username = envService.get('HACIENDA_USERNAME');
+    const password = envService.get('HACIENDA_PASSWORD');
+    const clientId = envService.get('HACIENDA_CLIENT_ID');
+    const tokenUrl = envService.get('HACIENDA_TOKEN_URL');
 
     // Verificar que todas las credenciales están disponibles
     if (!username || !password || !clientId || !tokenUrl) {
@@ -75,8 +75,8 @@ export const getAccessToken = async (): Promise<TokenResponse> => {
 export const refreshAccessToken = async (refreshToken: string): Promise<TokenResponse> => {
   try {
     // Obtener credenciales desde las variables de entorno
-    const clientId = envService.get('VITE_HACIENDA_CLIENT_ID');
-    const tokenUrl = envService.get('VITE_HACIENDA_TOKEN_URL');
+    const clientId = envService.get('HACIENDA_CLIENT_ID');
+    const tokenUrl = envService.get('HACIENDA_TOKEN_URL');
 
     // Verificar que todas las credenciales están disponibles
     if (!refreshToken || !clientId || !tokenUrl) {


### PR DESCRIPTION
## Summary
- update haciendaAuthService to read env vars without `VITE_` prefix
- verify build succeeds

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684505d7ad448321aa6501b01d27f616